### PR TITLE
Fix HTML export template injection

### DIFF
--- a/qualifica-ri-mvp.html
+++ b/qualifica-ri-mvp.html
@@ -446,7 +446,7 @@
 
     function downloadHTML() {
       const content = byId('note').innerHTML;
-      const tpl = `<!DOCTYPE html><html lang="pt-br"><head><meta charset="utf-8"><title>Nota Devolutiva</title></head><body>{content}</body></html>`.replace('{{content}}', content);
+      const tpl = `<!DOCTYPE html><html lang="pt-br"><head><meta charset="utf-8"><title>Nota Devolutiva</title></head><body>${content}</body></html>`;
       const blob = new Blob([tpl], {type:'text/html'});
       const a = document.createElement('a');
       a.href = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- fix the HTML export template so the generated file contains the rendered note content

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68dede8d3cf48332b696dac2396a6c90